### PR TITLE
Improve mobile layout width

### DIFF
--- a/style.css
+++ b/style.css
@@ -195,8 +195,11 @@ body.mild-glow {
 
   .navbar-inner {
     width: 100%;
+    max-width: 100vw;
     box-sizing: border-box;
     justify-content: space-between;
+    margin: 0;
+    padding: 5px 8px;
   }
 
   .mobile-menu {
@@ -262,6 +265,21 @@ body.mild-glow {
 
   .navbar.expanded+.nav-overlay {
     display: block;
+  }
+
+  #goalsView {
+    max-width: 100vw;
+    margin: 0 0 30px 0;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  #goalsView .container,
+  .main-layout {
+    max-width: 100vw;
+    margin: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -1453,14 +1471,14 @@ h2 {
 }
 
 #travelMap {
-  flex: 0 1 78%;
+  flex: 1 1 100%;
   width: 100%;
   height: 300px;
   border: 1px solid #ccc;
 }
 
 #travelTagFilters {
-  flex: 1 1 22%;
+  flex: 1 1 100%;
   display: flex;
   flex-direction: column;
   gap: 4px;


### PR DESCRIPTION
## Summary
- Remove side margins on mobile by setting full-width layout containers
- Make travel map and tag filter span 100% width on small screens
- Tighten navbar padding for better use of space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5077c9083279042ba8d12ce5210