### PR TITLE
Ensure mobile CSS refresh by cache-busting stylesheet link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
   <meta charset="UTF-8" />
   <title>Places</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="style.css?v=20250829" />
+  <link id="page-style" rel="stylesheet" />
+  <script>
+    document.getElementById('page-style').href = 'style.css?v=' + Date.now();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />

--- a/report.html
+++ b/report.html
@@ -5,7 +5,10 @@
     <meta charset="UTF-8" />
       <title>Daily Task Report – Places</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="style.css?v=20250829" />
+    <link id="page-style" rel="stylesheet" />
+    <script>
+      document.getElementById('page-style').href = 'style.css?v=' + Date.now();
+    </script>
     <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon.png">
 </head>

--- a/settings.html
+++ b/settings.html
@@ -4,7 +4,10 @@
   <meta charset="UTF-8" />
     <title>Settings - Places</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="style.css?v=20250829" />
+  <link id="page-style" rel="stylesheet" />
+  <script>
+    document.getElementById('page-style').href = 'style.css?v=' + Date.now();
+  </script>
 </head>
 <body>
   <nav class="navbar">


### PR DESCRIPTION
## Summary
- append timestamp to CSS link in HTML files to bust cache on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ffb3bdc08327adb114979097a1aa