### PR TITLE
Allow travel map tile wrapping and enforce tile bounds

### DIFF
--- a/js/travel.js
+++ b/js/travel.js
@@ -239,7 +239,11 @@ export async function initTravelPanel() {
   }).setView([20, 0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '© OpenStreetMap contributors',
-    noWrap: true
+    noWrap: false,
+    bounds: [
+      [-85.05112878, -180],
+      [85.05112878, 180]
+    ]
   }).addTo(map);
   map.on('moveend', updateVisiblePlacemarkList);
   resizeTravelMap();


### PR DESCRIPTION
## Summary
- Remove tile noWrap restriction and define bounding box on the travel map layer to prevent invalid tile requests.

## Testing
- `npm test`
- Computed tile coordinates near map bounds to verify they stay within [0, 2^z-1]

------
https://chatgpt.com/codex/tasks/task_e_68b5b0d389a08327ab63ef0d1cccb4e7