### PR TITLE
Use env variables for Firebase config

### DIFF
--- a/js/firebaseConfig.js
+++ b/js/firebaseConfig.js
@@ -1,21 +1,29 @@
 // Public Firebase web config for the Places app.
-// Replace these values when moving to a new Firebase project.
+// Values are loaded from environment variables when available so that
+// sensitive credentials are not committed to source control.
+
+const env =
+  (typeof process !== "undefined" && process.env) ||
+  (typeof import.meta !== "undefined" && import.meta.env) ||
+  {};
 
 const DEFAULT_CONFIG = {
-  apiKey: "secrets.APIKEY",
-  authDomain: "secrets.AUTHDOMAIN",
-  projectId: "secrets.PROJECTID",
-  storageBucket: "secrets.STORAGEBUCKET",
-  messagingSenderId: "secrets.MESSAGINGSENDERID",
-  appId: "secrets.APPID",
-  measurementId: "secrets.MEASUREMENTID"
+  apiKey: env.FIREBASE_API_KEY || "secrets.APIKEY",
+  authDomain: env.FIREBASE_AUTH_DOMAIN || "secrets.AUTHDOMAIN",
+  projectId: env.FIREBASE_PROJECT_ID || "secrets.PROJECTID",
+  storageBucket: env.FIREBASE_STORAGE_BUCKET || "secrets.STORAGEBUCKET",
+  messagingSenderId:
+    env.FIREBASE_MESSAGING_SENDER_ID || "secrets.MESSAGINGSENDERID",
+  appId: env.FIREBASE_APP_ID || "secrets.APPID",
+  measurementId: env.FIREBASE_MEASUREMENT_ID || "secrets.MEASUREMENTID",
 };
 
 // Optionally allow runtime override (e.g., from a script tag before main.js):
 // <script>window.firebaseConfig = { apiKey: '...', projectId: '...' };</script>
-const config = (typeof window !== 'undefined' && window.firebaseConfig)
-  ? window.firebaseConfig
-  : DEFAULT_CONFIG;
+const config =
+  typeof window !== "undefined" && window.firebaseConfig
+    ? window.firebaseConfig
+    : DEFAULT_CONFIG;
 
 export default config;
 


### PR DESCRIPTION
## Summary
- load Firebase settings from environment variables to avoid committing credentials

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1057ea48327854d1d66fe44313f