### PR TITLE
Add horizontal padding to decision buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -845,7 +845,7 @@ button:hover {
 }
 
 .button-row button {
-  padding: 4px 0px;
+  padding: 4px 12px;
   margin: 0;
   height: 30px;
   font-size: 0.9em;


### PR DESCRIPTION
## Summary
- add horizontal padding to buttons inside decision button rows to keep their labels from touching the edges

## Testing
- `vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68e3f5d845048327a1907aea6533463e