### PR TITLE
Remove legacy helpers module and refresh cache

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,1 +1,0 @@
-export { pickDate, linkify } from './travelUtils.js';

--- a/js/travel.js
+++ b/js/travel.js
@@ -3,7 +3,7 @@ import { getRandomPlaces } from './samplePlaces.js';
 import {
   pickDate,
   linkify
-} from './helpers.js';
+} from './travelUtils.js';
 
 const BASE_KEY = 'travelData';
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,12 @@
-const CACHE_NAME = 'places-cache-v3';
+const CACHE_NAME = 'places-cache-v4';
 const OFFLINE_URLS = [
   './',
   './index.html',
   './style.css',
   './js/main.js',
-  './js/travel.js'
+  './js/travel.js',
+  './js/travelUtils.js',
+  './js/events.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- import travel utility helpers directly and drop the stale helpers module
- bump the service worker cache name and include module scripts in the offline precache so old assets are evicted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e407acb23083278a6a7a341809ea23