### PR TITLE
Increase horizontal padding on movie status tabs

### DIFF
--- a/style.css
+++ b/style.css
@@ -2418,7 +2418,7 @@ h2 {
 
 .movie-tab {
   flex: 1 1 0;
-  padding: 6px;
+  padding: 6px 12px;
   border: 1px solid #ccc;
   background: #f8f8f8;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- expand the `.movie-tab` padding to add more horizontal space around the movie status buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4069d00a88327b605d737492c3c7a