### PR TITLE
Expose firebase config on window for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Places App
+
+## Inspecting runtime Firebase configuration
+
+When the app loads it exposes the effective Firebase configuration on the
+`window.__placesFirebaseConfig` global. Open the browser DevTools console on the
+running app and execute:
+
+```js
+window.__placesFirebaseConfig
+```
+
+This logs the configuration object that Firebase initialized with, letting you
+confirm whether the default keys or any runtime overrides (for example
+`window.firebaseConfig`) were used.
+
+You can also check `firebase.app().options` after the app initializes Firebase.

--- a/js/firebaseConfig.js
+++ b/js/firebaseConfig.js
@@ -27,4 +27,8 @@ const config =
     ? window.firebaseConfig
     : DEFAULT_CONFIG;
 
+if (typeof window !== "undefined") {
+  window.__placesFirebaseConfig = config;
+}
+
 export default config;


### PR DESCRIPTION
## Summary
- expose the resolved firebase configuration on a global so it can be inspected at runtime
- document how to read the config from the browser console

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40715b9008327b9fd3e1a0a123373