### PR TITLE
Collapse the mobile placemark list until search results appear

### DIFF
--- a/js/travel.js
+++ b/js/travel.js
@@ -62,6 +62,22 @@ let tableBody = null;
 let selectedPlaceRef = null;
 let detailsEditState = { place: null, editing: false };
 let savePlaceEdits = null;
+let searchResultsListEl = null;
+
+function updateMobilePlacemarkListState() {
+  if (!placemarkListEl) return;
+  const isMobile = window.matchMedia('(max-width: 600px)').matches;
+  if (!isMobile) {
+    placemarkListEl.classList.remove(
+      'placemark-list--mobile-collapsed',
+      'placemark-list--mobile-expanded'
+    );
+    return;
+  }
+  const hasResults = !!(searchResultsListEl && searchResultsListEl.childElementCount > 0);
+  placemarkListEl.classList.toggle('placemark-list--mobile-collapsed', !hasResults);
+  placemarkListEl.classList.toggle('placemark-list--mobile-expanded', hasResults);
+}
 
 function resizeTravelMap() {
   const mapEl = document.getElementById('travelMap');
@@ -73,8 +89,13 @@ function resizeTravelMap() {
   const height = Math.min(rect.width, availableHeight);
   mapEl.style.height = `${height}px`;
   if (listEl) {
-    listEl.style.maxHeight = `${height}px`;
-    listEl.style.height = `${height}px`;
+    if (window.innerWidth <= 600) {
+      listEl.style.maxHeight = '';
+      listEl.style.height = '';
+    } else {
+      listEl.style.maxHeight = `${height}px`;
+      listEl.style.height = `${height}px`;
+    }
   }
   if (detailsEl) {
     if (window.innerWidth >= 1024) {
@@ -87,6 +108,7 @@ function resizeTravelMap() {
     map.invalidateSize();
   }
   updateVisiblePlacemarkList();
+  updateMobilePlacemarkListState();
 }
 
 window.addEventListener('resize', resizeTravelMap);
@@ -701,8 +723,10 @@ export async function initTravelPanel() {
   const resultsList = document.getElementById('placeResults');
   const searchPlaceBtn = document.getElementById('placeSearchBtn');
   const tagFiltersDiv = document.getElementById('travelTagFilters');
+  searchResultsListEl = resultsList;
   placemarkListEl = document.getElementById('placemarkList');
   placemarkDetailsEl = document.getElementById('placemarkDetails');
+  updateMobilePlacemarkListState();
   const placeCountEl = document.getElementById('placeCount');
   const paginationDiv = document.getElementById('paginationControls');
   const prevPageBtn = document.getElementById('prevPageBtn');
@@ -1305,6 +1329,7 @@ export async function initTravelPanel() {
       if (!selectedPlaceRef && !detailsEditState.editing) {
         renderPlacemarkOverview();
       }
+      updateMobilePlacemarkListState();
     };
     placeInput?.setAttribute('autocomplete', 'off');
     placeInput?.addEventListener('input', e => {
@@ -1560,6 +1585,8 @@ export async function initTravelPanel() {
       resultsList?.append(card);
     });
 
+    updateMobilePlacemarkListState();
+
     const coords = parseCoordinates(term);
     if (coords) {
       const { lat, lon } = coords;
@@ -1598,6 +1625,7 @@ export async function initTravelPanel() {
         config
       );
       resultsList?.append(card);
+      updateMobilePlacemarkListState();
       const showDetails = () => {
         renderSearchResultDetails(
           {
@@ -1704,6 +1732,8 @@ export async function initTravelPanel() {
       li.textContent = 'Search failed. Please try again.';
       resultsList?.append(li);
     }
+
+    updateMobilePlacemarkListState();
   };
 
   placeInput?.addEventListener('keydown', e => {

--- a/style.css
+++ b/style.css
@@ -1549,6 +1549,28 @@ h2 {
   overflow: hidden;
 }
 
+@media (max-width: 600px) {
+  #placemarkList {
+    transition: max-height 0.3s ease, padding 0.3s ease;
+  }
+
+  #placemarkList.placemark-list--mobile-collapsed {
+    max-height: 72px;
+    overflow: hidden;
+    padding-bottom: 4px;
+  }
+
+  #placemarkList.placemark-list--mobile-collapsed #placeResults {
+    display: none;
+  }
+
+  #placemarkList.placemark-list--mobile-expanded {
+    max-height: min(70vh, 420px);
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+}
+
 #travelMap {
   flex: 1 1 100%;
   width: 100%;


### PR DESCRIPTION
## Summary
- add a responsive state tracker that collapses the placemark list on mobile until results are rendered
- adjust travel map resizing to avoid forcing heights that break the mobile collapse
- style the placemark list for collapsed and expanded mobile states

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c0d48a1c832783e1c7e7ea0bf969)